### PR TITLE
ci(github): add releases build sanity check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,13 @@
 name: Build
 
-on: workflow_dispatch
+on: push
 
 jobs:
-  build_linux_debian:
-    name: Build Linux Debian
-    runs-on: ubuntu-22.04
+  build_deb_release:
+    name: Build DEB Release
+    runs-on: ubuntu-latest
+    container:
+      image: ivangabriele/tauri:debian-bullseye-18
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,40 +21,58 @@ jobs:
       - name: Install
         run: yarn
       - name: Build
-        run: yarn build:linux:debian
+        run: yarn release:deb
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-release-deb
+          path: src-tauri/target/release/bundle/deb/*.deb
+          retention-days: 1
 
-  # build_macos:
-  #   name: Build macOS
-  #   runs-on: macos-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: true
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         cache: yarn
-  #         node-version: 20
-  #     - name: Install
-  #       run: yarn
-  #     - name: Build
-  #       run: yarn build
+  build_dmg_release:
+    name: Build DMG Release
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: 20
+      - name: Install
+        run: yarn
+      - name: Build
+        run: yarn release:dmg
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-release-dmg
+          path: src-tauri/target/release/bundle/dmg/*.dmg
+          retention-days: 1
 
-  # build_windows:
-  #   name: Build Windows
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: true
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         cache: yarn
-  #         node-version: 20
-  #     - name: Install
-  #       run: yarn
-  #     - name: Build
-  #       run: yarn build
+  build_msi_release:
+    name: Build MSI Release
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: 20
+      - name: Install
+        run: yarn
+      - name: Build
+        run: yarn release:msi
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-release-msi
+          path: src-tauri/target/release/bundle/msi/*.msi
+          retention-days: 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ivangabriele/tauri:debian-bullseye-18
-    env:
-      DISABLE_ESLINT_PLUGIN: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Add build workflow to sanity check that release bundles can be built in `deb`, `dmg` and `msi`.

## Checklist

- [x] I updated the documentation accordingly. Or I don't need to.
- [x] I updated the tests accordingly. Or I don't need to.
