### PR TITLE
fix(dev-deps): enforce ws to v>=8.17.1 [security]

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
     "vite": "5.3.1",
     "which": "4.0.0"
   },
+  "resolutions": {
+    "ws": ">=8.17.1"
+  },
   "lint-staged": {
     "*.{json,md,yaml,yml}": "prettier --write",
     "*.{ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12389,9 +12389,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.13.0":
-  version: 8.13.0
-  resolution: "ws@npm:8.13.0"
+"ws@npm:>=8.17.1":
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -12400,22 +12400,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/1769532b6fdab9ff659f0b17810e7501831d34ecca23fd179ee64091dd93a51f42c59f6c7bb4c7a384b6c229aca8076fb312aa35626257c18081511ef62a161d
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.11.0, ws@npm:^8.8.0":
-  version: 8.17.0
-  resolution: "ws@npm:8.17.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10/5e1dcb0ae70c6e2f158f5b446e0a72a2cd335b07aba73ee1872e9bae1285382286a10e53ed479db21bdd690a5dfd05641a768611ebb236253c62fefa43ef58b4
+  checksum: 10/4264ae92c0b3e59c7e309001e93079b26937aab181835fb7af79f906b22cd33b6196d96556dafb4e985742dd401e99139572242e9847661fdbc96556b9e6902d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fix [`ws`CWE-476 vulnrability](https://github.com/ivangabriele/clamav-desktop/security/dependabot/55).

## Checklist

- [x] I updated the documentation accordingly. Or I don't need to.
- [x] I updated the tests accordingly. Or I don't need to.
